### PR TITLE
Get by queries

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,11 @@
-import React from 'react';
-import logo from './logo.svg';
-import './App.css';
+import React from "react";
+import { JobForm } from "./components/JobForm/JobForm";
+import "./App.css";
 
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      <JobForm />
     </div>
   );
 }

--- a/src/components/JobForm/JobForm.test.tsx
+++ b/src/components/JobForm/JobForm.test.tsx
@@ -1,10 +1,12 @@
-import { render, screen, logRoles, getByRole } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { JobForm } from "./JobForm";
 
 describe("JobForm", () => {
-  test("render correctly", () => {
+  test("render correctly with getByRole", () => {
     render(<JobForm />);
-    const nameElm = screen.getByLabelText("Name"); // label text of the form element also we can use eg {selector: "input"} for conflicting labels
+    const nameElm = screen.getByRole("textbox", {
+      name: "Name",
+    }); // label text of the form element also we can use eg {selector: "input"} for conflicting labels
     expect(nameElm).toBeInTheDocument();
 
     const bioElm = screen.getByRole("textbox", {
@@ -24,12 +26,30 @@ describe("JobForm", () => {
     const termsElm = screen.getByRole("checkbox");
     expect(termsElm).toBeInTheDocument();
 
+    const submitElm = screen.getByRole("button");
+    expect(submitElm).toBeInTheDocument();
+  });
+
+  test("render correctly with getByPlaceholderText", () => {
+    render(<JobForm />);
+    const nameElmwithPlaceholder = screen.getByPlaceholderText("Fullname");
+    expect(nameElmwithPlaceholder).toBeInTheDocument();
+  });
+
+  test("render correctly with getByLabelText", () => {
+    render(<JobForm />);
+    const nameElm = screen.getByLabelText("Name"); // label text of the form element also we can use eg {selector: "input"} for conflicting labels
+    expect(nameElm).toBeInTheDocument();
+
     const termsElm2 = screen.getByLabelText(
       "I agree to the terms and conditions"
     ); // works well with wrapped label
     expect(termsElm2).toBeInTheDocument();
+  });
 
-    const submitElm = screen.getByRole("button");
-    expect(submitElm).toBeInTheDocument();
+  test("render correctly with getByText", () => {
+    render(<JobForm />);
+    const paragraphElement = screen.getByText("All fields are mandatory");
+    expect(paragraphElement).toBeInTheDocument();
   });
 });

--- a/src/components/JobForm/JobForm.test.tsx
+++ b/src/components/JobForm/JobForm.test.tsx
@@ -58,4 +58,10 @@ describe("JobForm", () => {
     const inputWithValue = screen.getByDisplayValue("Sushil"); // input value
     expect(inputWithValue).toBeInTheDocument();
   });
+
+  test("render correctly with getByAltText", () => {
+    render(<JobForm />);
+    const imageElement = screen.getByAltText("a person with a laptop"); // img alt attribute
+    expect(imageElement).toBeInTheDocument();
+  });
 });

--- a/src/components/JobForm/JobForm.test.tsx
+++ b/src/components/JobForm/JobForm.test.tsx
@@ -64,4 +64,10 @@ describe("JobForm", () => {
     const imageElement = screen.getByAltText("a person with a laptop"); // img alt attribute
     expect(imageElement).toBeInTheDocument();
   });
+
+  test("render correctly with getByTitle", () => {
+    render(<JobForm />);
+    const spanWithTitle = screen.getByTitle("close"); // title attribute
+    expect(spanWithTitle).toBeInTheDocument();
+  });
 });

--- a/src/components/JobForm/JobForm.test.tsx
+++ b/src/components/JobForm/JobForm.test.tsx
@@ -52,4 +52,10 @@ describe("JobForm", () => {
     const paragraphElement = screen.getByText("All fields are mandatory");
     expect(paragraphElement).toBeInTheDocument();
   });
+
+  test("render correctly with getByDisplayValue", () => {
+    render(<JobForm />);
+    const inputWithValue = screen.getByDisplayValue("Sushil"); // input value
+    expect(inputWithValue).toBeInTheDocument();
+  });
 });

--- a/src/components/JobForm/JobForm.test.tsx
+++ b/src/components/JobForm/JobForm.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen, logRoles, getByRole } from "@testing-library/react";
+import { JobForm } from "./JobForm";
+
+describe("JobForm", () => {
+  test("render correctly", () => {
+    render(<JobForm />);
+    const nameElm = screen.getByRole("textbox");
+    expect(nameElm).toBeInTheDocument();
+
+    const jobLocationElm = screen.getByRole("combobox");
+    expect(jobLocationElm).toBeInTheDocument();
+
+    const termsElm = screen.getByRole("checkbox");
+    expect(termsElm).toBeInTheDocument();
+
+    const submitElm = screen.getByRole("button");
+    expect(submitElm).toBeInTheDocument();
+  });
+});

--- a/src/components/JobForm/JobForm.test.tsx
+++ b/src/components/JobForm/JobForm.test.tsx
@@ -4,8 +4,21 @@ import { JobForm } from "./JobForm";
 describe("JobForm", () => {
   test("render correctly", () => {
     render(<JobForm />);
-    const nameElm = screen.getByRole("textbox");
+    const nameElm = screen.getByRole("textbox", {
+      name: "Name",
+    });
     expect(nameElm).toBeInTheDocument();
+
+    const bioElm = screen.getByRole("textbox", {
+      name: "Bio",
+    });
+    expect(bioElm).toBeInTheDocument();
+
+    const pageHeading = screen.getByRole("heading", { level: 1 }); // we can use level for heading
+    expect(pageHeading).toBeInTheDocument();
+
+    const sectionHeading = screen.getByRole("heading", { level: 2 });
+    expect(sectionHeading).toBeInTheDocument();
 
     const jobLocationElm = screen.getByRole("combobox");
     expect(jobLocationElm).toBeInTheDocument();

--- a/src/components/JobForm/JobForm.test.tsx
+++ b/src/components/JobForm/JobForm.test.tsx
@@ -70,4 +70,10 @@ describe("JobForm", () => {
     const spanWithTitle = screen.getByTitle("close"); // title attribute
     expect(spanWithTitle).toBeInTheDocument();
   });
+
+  test("render correctly with getByTestId", () => {
+    render(<JobForm />);
+    const divWithTestId = screen.getByTestId("custom-element"); // title attribute
+    expect(divWithTestId).toBeInTheDocument();
+  });
 });

--- a/src/components/JobForm/JobForm.test.tsx
+++ b/src/components/JobForm/JobForm.test.tsx
@@ -4,9 +4,7 @@ import { JobForm } from "./JobForm";
 describe("JobForm", () => {
   test("render correctly", () => {
     render(<JobForm />);
-    const nameElm = screen.getByRole("textbox", {
-      name: "Name",
-    });
+    const nameElm = screen.getByLabelText("Name"); // label text of the form element also we can use eg {selector: "input"} for conflicting labels
     expect(nameElm).toBeInTheDocument();
 
     const bioElm = screen.getByRole("textbox", {
@@ -25,6 +23,11 @@ describe("JobForm", () => {
 
     const termsElm = screen.getByRole("checkbox");
     expect(termsElm).toBeInTheDocument();
+
+    const termsElm2 = screen.getByLabelText(
+      "I agree to the terms and conditions"
+    ); // works well with wrapped label
+    expect(termsElm2).toBeInTheDocument();
 
     const submitElm = screen.getByRole("button");
     expect(submitElm).toBeInTheDocument();

--- a/src/components/JobForm/JobForm.tsx
+++ b/src/components/JobForm/JobForm.tsx
@@ -1,0 +1,42 @@
+export const JobForm = () => {
+  return (
+    <>
+      <h1>Job application form</h1>
+      <h2>Section 1</h2>
+      <p>All fields are mandatory</p>
+      <span title="close">X</span>
+      <img src="https://via.placeholder.com/150" alt="a person with a laptop" />
+      <div data-testid="custom-element">Custom HTML element</div>
+      <form>
+        <div>
+          <label htmlFor="name">Name</label>
+          <input
+            type="text"
+            id="name"
+            placeholder="Fullname"
+            value="Sushil"
+            onChange={() => {}}
+          />
+        </div>
+        <div>
+          <label htmlFor="job-location">Job location</label>
+          <select id="job-location">
+            <option value="">Select a country</option>
+            <option value="US">United States</option>
+            <option value="GB">United Kingdom</option>
+            <option value="CA">Canada</option>
+            <option value="IN">Nepal</option>
+            <option value="AU">Australia</option>
+          </select>
+        </div>
+        <div>
+          <label>
+            <input type="checkbox" id="terms" /> I agree to the terms and
+            conditions
+          </label>
+        </div>
+        <button disabled>Submit</button>
+      </form>
+    </>
+  );
+};

--- a/src/components/JobForm/JobForm.tsx
+++ b/src/components/JobForm/JobForm.tsx
@@ -19,6 +19,10 @@ export const JobForm = () => {
           />
         </div>
         <div>
+          <label htmlFor="bio">Bio</label>
+          <textarea id="bio" />
+        </div>
+        <div>
           <label htmlFor="job-location">Job location</label>
           <select id="job-location">
             <option value="">Select a country</option>

--- a/src/components/skills/skills.test.tsx
+++ b/src/components/skills/skills.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from "@testing-library/react";
+import Skills from "./skills";
+
+describe("Skills", () => {
+  const skills: string[] = ["HTML", "CSS", "JAVASCRIPT"];
+  it("testing getByAllRole", () => {
+    render(<Skills skills={skills} />);
+    const listItemElements = screen.getAllByRole("listitem");
+    expect(listItemElements).toHaveLength(skills.length); // as we passed 3 skills
+  });
+});

--- a/src/components/skills/skills.tsx
+++ b/src/components/skills/skills.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { SkillsProps } from "./skills.types";
+
+export default function Skills({ skills }: SkillsProps) {
+  return (
+    <>
+      <ul>
+        {skills.map((skill) => (
+          <li key={skill}>{skill}</li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/src/components/skills/skills.types.ts
+++ b/src/components/skills/skills.types.ts
@@ -1,0 +1,3 @@
+export type SkillsProps = {
+  skills: string[];
+};


### PR DESCRIPTION
getBy**(...)** class of queries return the matching node for a query, and throws a descriptive error if no elements match or if more than one match is found

The suffix can be one of **Role, LabelText, PlaceholderText, Text, DisplayValue, AltText, Title** and **TestId**